### PR TITLE
Derive HTTP::path value from HTTP::uri value instead of falling back to /

### DIFF
--- a/src/irulehttp.tcl
+++ b/src/irulehttp.tcl
@@ -641,7 +641,7 @@ proc ::testcl::HTTP::path {args} {
   
   variable uri
   if { ![info exists uri] } {
-    set uri /
+    set uri [HTTP::uri]
   }
 
   if { ![regexp {^([A-z]+://[^/]+)(.*)} $uri match host pathquery] } {


### PR DESCRIPTION
We are testing URI rewrites with expectation set for HTTP::uri. The changed URI can be tested through HTTP::path, but in the case that the rewrite doesn't take place HTTP::path returns /.