### PR TITLE
Make the class command apply the operator to keys, not values

### DIFF
--- a/src/classes.tcl
+++ b/src/classes.tcl
@@ -92,7 +92,7 @@ proc ::testcl::class {cmd args} {
       for {set i 0} {$i < [llength $clazz] / 2} {incr i} {
         set element_name [lindex $clazz [expr 2 * $i]]
         set element_value [lindex $clazz [expr 2 * $i + 1]]
-        if "\$element_value $operator \$item" $return_command
+        if "\$element_name $operator \$item" $return_command
       }
       eval $return_failure_block
     }
@@ -105,7 +105,7 @@ proc ::testcl::class {cmd args} {
       for {set i 0} {$i < [llength $clazz] / 2} {incr i} {
         set element_name [lindex $clazz [expr 2 * $i]]
         set element_value [lindex $clazz [expr 2 * $i + 1]]
-        if "\$item $operator \$element_value" $return_command
+        if "\$item $operator \$element_name" $return_command
       }
       eval $return_failure_block
     }

--- a/test/test_class.tcl
+++ b/test/test_class.tcl
@@ -18,16 +18,17 @@ class configure protocols {
 }
 
 if { $::tcl_platform(platform) eq "java" } {
-  assertStringEquals [class search -value server ends_with "0.1"] "192.168.0.1"
-  assertStringEquals [class search -name server ends_with "0.2"] "server2"
+  assertStringEquals [class search -value server ends_with "r1"] "192.168.0.1"
+  assertStringEquals [class search -name server ends_with "r2"] "server2"
   assertStringEquals [class match -element "http://localhost" starts_with protocols] [list "http" "http://"]
   assertNumberEquals [class match -index "ftp://locahost" starts_with protocols] 2	
+  assertNumberEquals [class match -value "server1" eq server] "192.168.0.1"
 }
-assertNumberEquals [class search server eq "192.168.0.1"] 1
+assertNumberEquals [class search server eq "server1"] 1
 assertNumberEquals [class search server eq "doesn't exist"] 0
-assertNumberEquals [class search doesnt_exist eq "192.168.0.1"] 0
+assertNumberEquals [class search doesnt_exist eq "server1"] 0
 assertStringEquals [class -value search server eq "doesn't exist"] ""
-assertStringEquals [class -name search doesnt_exist eq "192.168.0.1"] ""
+assertStringEquals [class -name search doesnt_exist eq "server1"] ""
 assertNumberEquals [class size protocols] 3
 assertNumberEquals [class size doesnt_exist] 0
 assertStringEquals [class element 2 protocols] [list "ftp" "ftp://"]


### PR DESCRIPTION
As can be read in [this answer](https://devcentral.f5.com/questions/i-dont-understand-class-match-nor-class-search-pls-help-47979):

> the [class] command always compares a given input string with your datagroup entries names. It never uses the data portion of the containing entries for comparsion.

While TesTcl is currently matching datagroup values, not names, when using `class`.