### PR TITLE
Add support to advanced pool verification

### DIFF
--- a/examples/example_irule_pool_verification.tcl
+++ b/examples/example_irule_pool_verification.tcl
@@ -18,7 +18,7 @@ it "should set the right pool when available" {
 
   given_pools fallback go_to_bar
 
-  on HTTP::uri return "http://some.host.com/admin"
+  HTTP::header insert Host "some.host.com"
 
   verify "Final pool is the expected one after a match" "go_to_bar" eq { endstate_pool }
   

--- a/examples/example_irule_pool_verification.tcl
+++ b/examples/example_irule_pool_verification.tcl
@@ -1,0 +1,37 @@
+package require -exact testcl 1.0.13
+namespace import ::testcl::*
+
+# Comment out to suppress logging
+#log::lvSuppressLE info 0
+
+before {
+  event HTTP_REQUEST
+
+  class configure foo-datagroup {
+      "some.host.com" "go_to_bar"
+  }
+
+  on LB::server pool return fallback
+}
+
+it "should set the right pool when available" {
+
+  given_pools fallback go_to_bar
+
+  on HTTP::uri return "http://some.host.com/admin"
+
+  verify "Final pool is the expected one after a match" "go_to_bar" eq { endstate_pool }
+  
+  run irules/advanced_pool_verification_irule.tcl advanced_pools
+}
+
+it "should fallback to default LB::server default pool if nothing matches" {
+
+  given_pools fallback go_to_bar
+
+  on HTTP::uri return "http://wont.match/admin"
+
+  verify "Final pool should be defaults" "fallback" eq { endstate_pool }
+  
+  run irules/advanced_pool_verification_irule.tcl advanced_pools
+}

--- a/irules/advanced_pool_verification_irule.tcl
+++ b/irules/advanced_pool_verification_irule.tcl
@@ -1,4 +1,4 @@
-rule advances_pool {
+rule advanced_pools {
 
   when HTTP_REQUEST priority 100 {
       

--- a/irules/advanced_pool_verification_irule.tcl
+++ b/irules/advanced_pool_verification_irule.tcl
@@ -1,0 +1,19 @@
+rule advances_pool {
+
+  when HTTP_REQUEST priority 100 {
+      
+      set new_pool ""
+      set hostname [string tolower [getfield [HTTP::host] ":" 1]]      
+
+      if { not [ catch { set next_step [class match -value -- $hostname equals "foo-datagroup"] } ] } {
+          if { $next_step ne "" } {
+              set new_pool $next_step
+          }
+      }
+
+      if { [catch { pool $new_pool } ] } {
+          log local0. "Failed to find pool '$new_pool', sending to '[LB::server pool]'"
+          pool [LB::server pool]
+      }      
+  }
+}

--- a/src/global.tcl
+++ b/src/global.tcl
@@ -159,7 +159,7 @@ proc ::testcl::pool { name } {
 
    set rc [catch {lsearch -exact $availablePools $name} found]
 
-   log::log debug "rc=$rc   found=$found"
+   log::log debug "rc=$rc found=$found"
 
    if { $found >= 0} {
 
@@ -170,6 +170,6 @@ proc ::testcl::pool { name } {
        return -code 0 "pool $name"
    }
    
-   return -code 100 "pool $name"
+   return -code 1000 "pool $name"
 
 }

--- a/src/global.tcl
+++ b/src/global.tcl
@@ -2,6 +2,8 @@ package provide testcl 1.0.13
 package require log
 
 namespace eval ::testcl {
+    variable availablePools [list]
+    variable currentPool
   # namespace export accumulate
   # namespace export active_members
   # namespace export active_nodes
@@ -60,7 +62,7 @@ namespace eval ::testcl {
   # namespace export Operators
   # namespace export peer
   # namespace export persist
-  # namespace export pool
+   namespace export pool
   # namespace export priority
   # namespace export rateclass
   # namespace export redirect
@@ -146,4 +148,28 @@ proc ::testcl::log { faclvl msg } {
     }
 
     log::log $level $msg
+}
+
+proc ::testcl::pool { name } {
+
+   variable availablePools
+   variable currentPool
+
+   log::log debug "Available pools  => $availablePools"
+
+   set rc [catch {lsearch -exact $availablePools $name} found]
+
+   log::log debug "rc=$rc   found=$found"
+
+   if { $found >= 0} {
+
+       set currentPool $name
+
+       log::log debug "Current pool is now => $currentPool"
+       
+       return -code 0 "pool $name"
+   }
+   
+   return -code 100 "pool $name"
+
 }

--- a/src/it.tcl
+++ b/src/it.tcl
@@ -74,6 +74,17 @@ proc ::testcl::reset_expectations { } {
     log::log debug "Reset HTTP payload"
     unset HTTP::payload
   }
+  variable currentPool
+  if { [info exists currentPool] } {
+    log::log debug "Reset current pool"
+    unset currentPool
+  }
+  variable availablePools
+  if { [info exists availablePools] } {
+    log::log debug "Reset available pools"
+    set availablePools [list]
+  }
+
 }
 
 # testcl::before --

--- a/src/on.tcl
+++ b/src/on.tcl
@@ -205,3 +205,15 @@ proc ::testcl::expected {args} {
   log::log debug "expectation not found for $args (return code 1500)"
   return -code 1500 "expectation not found"
 }
+
+proc ::testcl::endstate_pool {} {
+  variable currentPool
+  if { [info exists currentPool] } {    
+    return $currentPool
+  }
+}
+
+proc ::testcl::given_pools { args } {
+    variable availablePools
+    set availablePools $args
+}


### PR DESCRIPTION
I ran into an issue where `endstate` would not do the job to verify the last `pool` set by an `iRule` when wrapped in a `catch` expression.

This PR attempts to address that by enriching the available building blocks with the following new statements:

- `given_pools`: where you can declare all available pools to be used
- `endstate_pool`: an easy way to get back the last pool set by the iRule

This way, you can have things like:

`verify "Final pool is the expected one after a match" "go_to_bar" eq { endstate_pool }`

which is super awesome to have handy!

Let me know what you think